### PR TITLE
Feature/multi file upload

### DIFF
--- a/app/controllers/concerns/upload_scoped.rb
+++ b/app/controllers/concerns/upload_scoped.rb
@@ -1,0 +1,12 @@
+module UploadScoped
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_upload
+  end
+
+  private
+    def set_upload
+      @upload = Upload.find_by(uuid: params[:upload_uuid])
+    end
+end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -24,7 +24,7 @@ class PaymentsController < ApplicationController
         price_data: {
           currency: "usd",
           unit_amount: project.quotes.last.price_cents,
-          product_data: { name: project.main_blend_file }
+          product_data: { name: project.blend_filepath }
         },
         quantity: 1
       }

--- a/app/controllers/project_batches_controller.rb
+++ b/app/controllers/project_batches_controller.rb
@@ -1,0 +1,18 @@
+class ProjectBatchesController < ApplicationController
+  include UploadScoped
+  allow_unauthenticated_access only: %i[ create ]
+
+  def create
+    @project_batch = @upload.new_project_batch(project_batch_params)
+    if @project_batch.save
+      redirect_to @upload, notice: "Projects created successfully!"
+    else
+      redirect_to @upload, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def project_batch_params
+      params.expect(blend_filepaths: [])
+    end
+end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,8 +1,12 @@
 class UploadsController < ApplicationController
   include UploadStashable
 
-  allow_unauthenticated_access
+  allow_unauthenticated_access only: %i[ index show new create ]
   before_action :set_upload, only: :show
+
+  def index
+    @uploads = authenticated? ? Current.user.uploads : Upload.from_session(session)
+  end
 
   def show
   end
@@ -29,7 +33,6 @@ class UploadsController < ApplicationController
     end
 
     def upload_params
-      # params.require(:upload).permit(:source_file, :uuid)
-      params.expect(upload: [ :source_file, :uuid ])
+      params.expect(upload: [ :uuid, files: [] ])
     end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -24,14 +24,14 @@ class Check < ApplicationRecord
         {
           job_id: "integrity-check",
           command: [
-            "/tmp/project/#{project.main_blend_file}",
+            "/tmp/project/#{project.blend_filepath}",
             "--python", "/tmp/scripts/integrity_check.py",
             "--",
             "--output-dir", "/tmp/output"
           ],
           image: Rails.env.production? ? {
             command: [ "python", "/tmp/scripts/get_blender_image.py",
-            "/tmp/project/#{project.main_blend_file}" ]
+            "/tmp/project/#{project.blend_filepath}" ]
           } : "blendergrid/blender:latest"
         }
       ],

--- a/app/models/project_batch.rb
+++ b/app/models/project_batch.rb
@@ -1,0 +1,14 @@
+class ProjectBatch
+  def initialize(upload:, blend_filepaths:)
+    @upload = upload
+    @blend_filepaths = blend_filepaths
+  end
+
+  def save
+    is_success = true
+    @blend_filepaths.each do |blend_filepath|
+      is_success &&= @upload.projects.create(blend_filepath:)
+    end
+    is_success
+  end
+end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -81,7 +81,7 @@ class Quote < ApplicationRecord
           {
             job_id:  "sample-frame-$frame",
             command: [
-              "/tmp/project/#{project.main_blend_file}",
+              "/tmp/project/#{project.blend_filepath}",
               "--python",
               "/tmp/scripts/init.py",
               "--python",

--- a/app/models/render.rb
+++ b/app/models/render.rb
@@ -39,7 +39,7 @@ class Render < ApplicationRecord
         {
           job_id: "frame-$frame",
           command: [
-            "/tmp/project/#{project.main_blend_file}",
+            "/tmp/project/#{project.blend_filepath}",
             "--python",
             "/tmp/scripts/init.py",
             "-o",
@@ -62,7 +62,7 @@ class Render < ApplicationRecord
         type: "render",
         created_by: "blendergrid-on-rails",
         project_uuid: project.uuid,
-        project_name: project.main_blend_file
+        project_name: project.blend_filepath
       }
     }
   end

--- a/app/models/swarm_engine.rb
+++ b/app/models/swarm_engine.rb
@@ -26,6 +26,7 @@ class SwarmEngine
 
     def topic_arn
       topic = "external-#{@swarm_engine_env}-topic"
+      Rails.logger.debug "Topic: #{topic}"
       "arn:aws:sns:#{@region}:#{@account_id}:#{topic}"
     end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -2,16 +2,25 @@ class Upload < ApplicationRecord
   include Uuidable
 
   belongs_to :user, optional: true
-  has_one_attached :source_file
+  has_many_attached :files
   has_many :projects
 
-  after_create :create_projects
+  after_create :find_blend_filepaths
 
   scope :from_session, ->(session) { where(uuid: Array(session[:upload_uuids])) }
 
+  def new_project_batch(blend_filepaths)
+    ProjectBatch.new(upload: self, blend_filepaths:)
+  end
+
   private
-    def create_projects
-      # TODO: Allow multiple projects per upload
-      projects.create(main_blend_file: source_file.blob.filename)
+    def find_blend_filepaths
+      self.blend_filepaths = files.select { |file|
+        file.blob.filename.extension == "blend"
+      }.map { |file| file.blob.filename.to_s }
+      save!
+      # TODO: If someone uploads a directory, make sure the relative file paths are
+      # preserved.
+      # TODO: Handle .zip files by looking inside the contents (in background jobs)
     end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,13 +25,15 @@
   <body>
     <nav>
       <%= link_to "Home", root_path %>
+      <%= link_to "Uploads", uploads_path %>
       <%= link_to "Projects", projects_path %>
       <%= link_to "Log in", new_session_path unless authenticated? %>
-      <%= link_to "Sign up", signup_path unless authenticated? %>
       <%= button_to "Log out", session_path, method: :delete if authenticated? %>
+      <%= link_to "Sign up", signup_path unless authenticated? %>
     </nav>
     <%= yield %>
 
     <%= debug params if Rails.env.development? %>
+    <%= debug session if Rails.env.development? %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,9 +31,10 @@
       <%= button_to "Log out", session_path, method: :delete if authenticated? %>
       <%= link_to "Sign up", signup_path unless authenticated? %>
     </nav>
+
     <%= yield %>
 
-    <%= debug params if Rails.env.development? %>
-    <%= debug session if Rails.env.development? %>
+    <%# debug params if Rails.env.development? %>
+    <%# debug session if Rails.env.development? %>
   </body>
 </html>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,9 +1,11 @@
-<% compact = local_assigns.fetch(:compact, local_assigns.key?(:project_counter)) %>
+<% full = local_assigns.fetch(:full, false) %>
 
 <%= tag.div id: dom_id(project) do %>
-  <h2>
-    <%= compact ? link_to(project.blend_filepath, project) : project.blend_filepath %>
-  </h2>
+  <% if full %>
+    <h1><%= project.blend_filepath %></h1>
+  <% else %>
+    <h2><%= link_to(project.blend_filepath, project) %></h2>
+  <% end %>
 
   <p>
     <%= "Project Status: #{project.status}" %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,6 +1,8 @@
+<% compact = local_assigns.fetch(:compact, local_assigns.key?(:project_counter)) %>
+
 <%= tag.div id: dom_id(project) do %>
   <h2>
-    <%= project.main_blend_file %>
+    <%= compact ? link_to(project.blend_filepath, project) : project.blend_filepath %>
   </h2>
 
   <p>
@@ -8,7 +10,7 @@
   </p>
 
   <% if project.checked? %>
-    <%= button_to "Calculate price", project_quote_path(project), method: :post %>
+    <%= button_to "Calculate price", project_quotes_path(project), method: :post %>
   <% elsif project.quoted? %>
     <%= render project.quote %>
     <%= form_with url: project_payments_path(project), method: :post,

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream_from :projects %>
 
-<%= render @project %>
+<%= render @project, full: true %>

--- a/app/views/uploads/_test.html.erb
+++ b/app/views/uploads/_test.html.erb
@@ -1,0 +1,5 @@
+<% variable = local_assigns.fetch(:variable, "FOO") %>
+<h3>
+  <%= variable %>
+  Fighters
+</h3>

--- a/app/views/uploads/_test.html.erb
+++ b/app/views/uploads/_test.html.erb
@@ -1,5 +1,0 @@
-<% variable = local_assigns.fetch(:variable, "FOO") %>
-<h3>
-  <%= variable %>
-  Fighters
-</h3>

--- a/app/views/uploads/_upload.html.erb
+++ b/app/views/uploads/_upload.html.erb
@@ -1,0 +1,24 @@
+<% compact = local_assigns.fetch(:compact, local_assigns.key?(:upload_counter)) %>
+<% title = "Upload - #{upload.created_at.localtime.iso8601}" %>
+
+<h2>
+  <%= compact ? link_to(title, upload) : title %>
+</h2>
+
+<% unless compact %>
+  <% if upload.blend_filepaths.present? %>
+    <h2><%= "Found #{pluralize(upload.blend_filepaths.count, ".blend file")}" %></h2>
+    <%= form_with url: upload_project_batches_path(upload), method: :post do |form| %>
+      <% upload.blend_filepaths.each do |filepath| %>
+        <%= form.check_box :blend_filepaths, { multiple: true }, filepath, nil %>
+        <%= form.label :blend_filepaths, filepath, value: filepath %>
+        <br>
+      <% end %>
+      <%= form.submit "Create Projects" %>
+    <% end %>
+  <% else %>
+    <p>No .blend files found. Processing uploads might still be in progress.</p>
+  <% end %>
+<% end %>
+
+<%= debug local_assigns %>

--- a/app/views/uploads/_upload.html.erb
+++ b/app/views/uploads/_upload.html.erb
@@ -1,24 +1,33 @@
-<% compact = local_assigns.fetch(:compact, local_assigns.key?(:upload_counter)) %>
+<% full = local_assigns.fetch(:full, false) %>
+
 <% title = "Upload - #{upload.created_at.localtime.iso8601}" %>
 
-<h2>
-  <%= compact ? link_to(title, upload) : title %>
-</h2>
+<% if full %>
+  <h1><%= title %></h1>
+<% else %>
+  <h2><%= link_to(title, upload) %></h2>
+<% end %>
 
-<% unless compact %>
-  <% if upload.blend_filepaths.present? %>
-    <h2><%= "Found #{pluralize(upload.blend_filepaths.count, ".blend file")}" %></h2>
-    <%= form_with url: upload_project_batches_path(upload), method: :post do |form| %>
-      <% upload.blend_filepaths.each do |filepath| %>
+<% if full %>
+  <%= form_with url: upload_project_batches_path(upload), method: :post do |form| %>
+
+    <h3><%= "Found #{pluralize(upload.blend_files.count, ".blend file")}" %></h3>
+    <% upload.blend_files.each.map(&:blob).map(&:filename).each do |filepath| %>
+      <%= form.check_box :blend_filepaths, { multiple: true }, filepath, nil %>
+      <%= form.label :blend_filepaths, filepath, value: filepath %>
+      <br>
+    <% end %>
+
+    <h3><%= "Found #{pluralize(upload.zip_files.count, ".zip file")}" %></h3>
+    <% upload.zip_files.each.map(&:blob).each do |blob| %>
+      <h4><%= blob.filename %></h4>
+      <% blob.metadata[:blend_filepaths]&.each do |filepath| %>
         <%= form.check_box :blend_filepaths, { multiple: true }, filepath, nil %>
         <%= form.label :blend_filepaths, filepath, value: filepath %>
         <br>
       <% end %>
-      <%= form.submit "Create Projects" %>
     <% end %>
-  <% else %>
-    <p>No .blend files found. Processing uploads might still be in progress.</p>
+
+    <%= form.submit "Create Projects" %>
   <% end %>
 <% end %>
-
-<%= debug local_assigns %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -1,3 +1,3 @@
 <h1>Uploads</h1>
 
-<%= render @uploads, compact: true %>
+<%= render @uploads %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Uploads</h1>
+
+<%= render @uploads, compact: true %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -4,8 +4,6 @@
 
 <h2>VEVE is lief ❤️</h2>
 
-<%= render "test", variable: "BAR" %>
-
 <%= form_with model: @upload do |form| %>
   <%= form.hidden_field :uuid, value: @upload.uuid %>
   <%= form.file_field :files,
@@ -15,5 +13,5 @@
                     direct_upload_url:
                       rails_direct_uploads_url(upload_uuid: @upload.uuid),
                   } %>
-  <%= form.submit "Upload" %>
+  <%= form.submit %>
 <% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -2,11 +2,14 @@
 
 <h1>Upload a .blend file</h1>
 
-<h2>VEVE ❤️</h2>
+<h2>VEVE is lief ❤️</h2>
+
+<%= render "test", variable: "BAR" %>
 
 <%= form_with model: @upload do |form| %>
   <%= form.hidden_field :uuid, value: @upload.uuid %>
-  <%= form.file_field :source_file,
+  <%= form.file_field :files,
+                  multiple: true,
                   direct_upload: true,
                   data: {
                     direct_upload_url:

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -1,3 +1,1 @@
-<%= turbo_stream_from "projects" %>
-
-<%= render @upload.projects %>
+<%= render @upload %>

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -1,1 +1,1 @@
-<%= render @upload %>
+<%= render @upload, full: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,11 @@ Rails.application.routes.draw do
   resources :users
   resource :session
   resources :passwords, param: :token
-  resources :uploads, param: :uuid
+  resources :uploads, param: :uuid do
+    resources :project_batches
+  end
   resources :projects, param: :uuid do
-    resource :quote
+    resources :quotes
 
     # TODO: Think of a better name than 'Payments'
     # TODO: For multi-project support, this should move somewhere else

--- a/config/swarm_engine.yml
+++ b/config/swarm_engine.yml
@@ -8,6 +8,7 @@ test:
 
 development:
   <<: *defaults
+  env: dev
 
 production:
   <<: *defaults

--- a/db/migrate/20250719000003_create_uploads.rb
+++ b/db/migrate/20250719000003_create_uploads.rb
@@ -2,7 +2,6 @@ class CreateUploads < ActiveRecord::Migration[8.0]
   def change
     create_table :uploads do |t|
       t.string :uuid, index: { unique: true }
-      t.json :blend_filepaths
       t.references :user
       t.timestamps
     end

--- a/db/migrate/20250719000003_create_uploads.rb
+++ b/db/migrate/20250719000003_create_uploads.rb
@@ -2,6 +2,7 @@ class CreateUploads < ActiveRecord::Migration[8.0]
   def change
     create_table :uploads do |t|
       t.string :uuid, index: { unique: true }
+      t.json :blend_filepaths
       t.references :user
       t.timestamps
     end

--- a/db/migrate/20250719000004_create_projects.rb
+++ b/db/migrate/20250719000004_create_projects.rb
@@ -4,7 +4,7 @@ class CreateProjects < ActiveRecord::Migration[8.0]
       t.references :upload
       t.string :uuid, index: { unique: true }
       t.string :status
-      t.string :main_blend_file
+      t.string :blend_filepath
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_000009) do
     t.integer "upload_id"
     t.string "uuid"
     t.string "status"
-    t.string "main_blend_file"
+    t.string "blend_filepath"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["upload_id"], name: "index_projects_on_upload_id"
@@ -101,6 +101,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_000009) do
 
   create_table "uploads", force: :cascade do |t|
     t.string "uuid"
+    t.json "blend_filepaths"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,7 +101,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_000009) do
 
   create_table "uploads", force: :cascade do |t|
     t.string "uuid"
-    t.json "blend_filepaths"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
This PR adds support for multiple file uploads and zip file uploads.

When multiple files are uploaded, we check the types of files:

- .blend files can be turned into projects
- .zip files are explored for .blend files
- the rest is just uploaded but otherwise ignored

Then we end up with a list of .blend files, either directly from the upload, or from inside .zip files. Every .blend file gets a checkbox, and a Project can be created from it.